### PR TITLE
Feature/common test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ before_script:
 script:
   - cd testsuite
   - cd NGSI-LD_TestSuite-master
-  - export EXCLUDED_TESTS="001|002|003|004|014|022|145|147|149|151|155|156|157|158|159|161|162"
+  - export EXCLUDED_TESTS="001|002|003|004|014|022|145|147|149|151|155|156|157|158|159|160|161|162"
   - export TEST_ENDPOINT="http://localhost:9090"
   - export ACC_ENDPOINT="http://localhost:4444"
   - export NOTIFY_ENDPOINT="http://localhost:4444/acc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,65 +14,61 @@ addons:
       - postgresql-9.6-postgis-2.3
       - npm
 
-before_script: >
-  psql -U postgres -c "create extension postgis;";
-  psql -U postgres -c "create database ngb;";
-  psql -U postgres -c "create user ngb with password 'ngb';";
-  psql -U postgres -c "alter database ngb owner to ngb;"  ;
-  psql -U postgres -c "grant all privileges on database ngb to ngb;";
-  psql -U postgres -c "alter role ngb superuser;";
+install:
+  - psql -U postgres -c "create extension postgis;"
+  - psql -U postgres -c "create database ngb;"
+  - psql -U postgres -c "create user ngb with password 'ngb';"
+  - psql -U postgres -c "alter database ngb owner to ngb;"
+  - psql -U postgres -c "grant all privileges on database ngb to ngb;"
+  - psql -U postgres -c "alter role ngb superuser;"
+  - mkdir kafka
+  - cd kafka
+  - wget http://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz
+  - tar -xzf kafka_2.12-2.2.0.tgz
+  - kafka_2.12-2.2.0/bin/zookeeper-server-start.sh kafka_2.12-2.2.0/config/zookeeper.properties > /dev/null 2>&1 &
+  - sleep 12
+  - kafka_2.12-2.2.0/bin/kafka-server-start.sh kafka_2.12-2.2.0/config/server.properties > /dev/null 2>&1 &
+  - sleep 2
+  - cd ..
+  - mkdir testsuite
+  - cd testsuite
+  - curl -LO https://github.com/FIWARE/NGSI-LD_TestSuite/archive/master.zip
+  - shasum -a 256 master.zip
+  - unzip -q master.zip
+  - rm master.zip
+  - cd NGSI-LD_TestSuite-master
+  - npm install
+  - cd ../..
 
-  mkdir kafka;
-  cd kafka;
-  wget http://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz;
-  tar -xzf kafka_2.12-2.2.0.tgz;
-  kafka_2.12-2.2.0/bin/zookeeper-server-start.sh kafka_2.12-2.2.0/config/zookeeper.properties > /dev/null 2>&1 &;
-  sleep 12;
-  kafka_2.12-2.2.0/bin/kafka-server-start.sh kafka_2.12-2.2.0/config/server.properties > /dev/null 2>&1 &;
-  sleep 2;
-
-  cd ..;
-  mkdir testsuite;
-  cd testsuite;
-  curl -LO https://github.com/FIWARE/NGSI-LD_TestSuite/archive/master.zip;
-  shasum -a 256 master.zip;
-  unzip -q master.zip;
-  rm master.zip;
-  cd NGSI-LD_TestSuite-master;
-  npm install;
-  cd ../..;
-
-script: >
-  cd $TRAVIS_BUILD_DIR;
-  mvn clean package -DskipDefault -PbuildForTest -B;
+before_script:
+  - cd $TRAVIS_BUILD_DIR
+  - mvn clean package -DskipDefault -PbuildForTest -B
+  - java -jar ./SpringCloudModules/eureka/target/eureka-server.jar > /dev/null 2>&1 &
+  #- java -jar ./SpringCloudModules/config-server/target/config-server.jar &
+  - sleep 10
+  - java -Dspring.profiles.active=aio -jar ./SpringCloudModules/gateway/target/gateway.jar > /dev/null 2>&1 &
+  - sleep 10
+  - java -Dspring.profiles.active=dev -jar ./AllInOneRunner/target/AllInOneRunner.jar > /dev/null 2>&1 &
+  - sleep 100
+  - while [ `curl -s -o /dev/null -w "%{http_code}" http://localhost:9090/scorpio/v1/info/` -eq 500 ]; do sleep 10; done
   
-  java -jar ./SpringCloudModules/eureka/target/eureka-server.jar > /dev/null 2>&1 &
-  sleep 10;
-  
-  java -Dspring.profiles.active=aio -jar ./SpringCloudModules/gateway/target/gateway.jar > /dev/null 2>&1 &;
-  sleep 10;
-  
-  java -Dspring.profiles.active=dev -jar ./AllInOneRunner/target/AllInOneRunner.jar > /dev/null 2>&1 &;
-  sleep 100;
-  
-  while [ `curl -s -o /dev/null -w "%{http_code}" http://localhost:9090/scorpio/v1/info/` -eq 500 ]; do sleep 10; done;
-  cd testsuite;
-  cd NGSI-LD_TestSuite-master;
-  node accumulator/accumulator.js &;
+script:
+  - cd testsuite
+  - cd NGSI-LD_TestSuite-master
+  - node accumulator/accumulator.js &;
+  - export EXCLUDED_TESTS="001|003|126|129|"
+  - export TEST_ENDPOINT="http://localhost:9090"
+  - export ACC_ENDPOINT="http://localhost:4444"
+  - export NOTIFY_ENDPOINT="http://localhost:4444/acc"
+  - export WEB_APP_PORT=4444
+  - npm test
+  - curl http://localhost:9090/scorpio/v1/info/
 
-  export EXCLUDED_TESTS="001|003|126|129|";
-  export TEST_ENDPOINT="http://localhost:9090";
-  export ACC_ENDPOINT="http://localhost:4444";
-  export NOTIFY_ENDPOINT="http://localhost:4444/acc";
-  export WEB_APP_PORT=4444;
-
-  npm test;
-  curl http://localhost:9090/scorpio/v1/info/
-
-after_script: >
-  cd kafka
-  kafka_2.12-2.2.0/bin/zookeeper-server-stop.sh
-  kafka_2.12-2.2.0/bin/kafka-server-stop.sh
+after_script:
+  - cd
+  - cd kafka
+  - kafka_2.12-2.2.0/bin/zookeeper-server-stop.sh
+  - kafka_2.12-2.2.0/bin/kafka-server-stop.sh
 
 # see https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure
 sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
   - export ACC_ENDPOINT="http://localhost:4444"
   - export NOTIFY_ENDPOINT="http://localhost:4444/acc"
   - export WEB_APP_PORT=4444
-  - node accumulator/accumulator.js &;
+  - node accumulator/accumulator.js &
   - npm test
   - curl http://localhost:9090/scorpio/v1/info/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 # use Java 8
 dist: trusty
 jdk:
-- oraclejdk8
+  - oraclejdk8
 
 services:
   - postgresql
@@ -11,61 +11,64 @@ addons:
   postgresql: 9.6
   apt:
     packages:
-    - postgresql-9.6-postgis-2.3
-    - npm
+      - postgresql-9.6-postgis-2.3
+      - npm
+
 before_script: >
-    psql -U postgres -c "create extension postgis;";
-    psql -U postgres -c "create database ngb;";
-    psql -U postgres -c "create user ngb with password 'ngb';";
-    psql -U postgres -c "alter database ngb owner to ngb;"  ;
-    psql -U postgres -c "grant all privileges on database ngb to ngb;";
-    psql -U postgres -c "alter role ngb superuser;";
-    mkdir kafka;
-    cd kafka;
-    wget http://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz;
-    tar -xzf kafka_2.12-2.2.0.tgz;
-    kafka_2.12-2.2.0/bin/zookeeper-server-start.sh kafka_2.12-2.2.0/config/zookeeper.properties > /dev/null 2>&1 &;
-    sleep 12;
-    kafka_2.12-2.2.0/bin/kafka-server-start.sh kafka_2.12-2.2.0/config/server.properties > /dev/null 2>&1 &;
-    sleep 2;
-    cd ..;
-    mkdir testsuite;
-    cd testsuite;
-    curl -LO https://github.com/FIWARE/NGSI-LD_TestSuite/archive/master.zip;
-    shasum -a 256 master.zip;
-    unzip -q master.zip;
-    rm master.zip;
-    cd NGSI-LD_TestSuite-master;
-    npm install;
-    cd ../..
-  
-  
+  psql -U postgres -c "create extension postgis;";
+  psql -U postgres -c "create database ngb;";
+  psql -U postgres -c "create user ngb with password 'ngb';";
+  psql -U postgres -c "alter database ngb owner to ngb;"  ;
+  psql -U postgres -c "grant all privileges on database ngb to ngb;";
+  psql -U postgres -c "alter role ngb superuser;";
+
+  mkdir kafka;
+  cd kafka;
+  wget http://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz;
+  tar -xzf kafka_2.12-2.2.0.tgz;
+  kafka_2.12-2.2.0/bin/zookeeper-server-start.sh kafka_2.12-2.2.0/config/zookeeper.properties > /dev/null 2>&1 &;
+  sleep 12;
+  kafka_2.12-2.2.0/bin/kafka-server-start.sh kafka_2.12-2.2.0/config/server.properties > /dev/null 2>&1 &;
+  sleep 2;
+
+  cd ..;
+  mkdir testsuite;
+  cd testsuite;
+  curl -LO https://github.com/FIWARE/NGSI-LD_TestSuite/archive/master.zip;
+  shasum -a 256 master.zip;
+  unzip -q master.zip;
+  rm master.zip;
+  cd NGSI-LD_TestSuite-master;
+  npm install;
+  cd ../..;
+
 script: >
-    cd $TRAVIS_BUILD_DIR;
-    mvn clean package -DskipDefault -PbuildForTest -B;
-    java -jar ./SpringCloudModules/eureka/target/eureka-server.jar > /dev/null 2>&1 &
- #- java -jar ./SpringCloudModules/config-server/target/config-server.jar &;
-    sleep 10;
-    java -Dspring.profiles.active=aio -jar ./SpringCloudModules/gateway/target/gateway.jar > /dev/null 2>&1 &;
-    sleep 10;
-    java -Dspring.profiles.active=dev -jar ./AllInOneRunner/target/AllInOneRunner.jar > /dev/null 2>&1 &;
-    sleep 100;
-    while [ `curl -s -o /dev/null -w "%{http_code}" http://localhost:9090/scorpio/v1/info/` -eq 500 ]; do sleep 10; done;
-    cd testsuite;
-    cd NGSI-LD_TestSuite-master;
-    node accumulator/accumulator.js &;
+  cd $TRAVIS_BUILD_DIR;
+  mvn clean package -DskipDefault -PbuildForTest -B;
+  
+  java -jar ./SpringCloudModules/eureka/target/eureka-server.jar > /dev/null 2>&1 &
+  sleep 10;
+  
+  java -Dspring.profiles.active=aio -jar ./SpringCloudModules/gateway/target/gateway.jar > /dev/null 2>&1 &;
+  sleep 10;
+  
+  java -Dspring.profiles.active=dev -jar ./AllInOneRunner/target/AllInOneRunner.jar > /dev/null 2>&1 &;
+  sleep 100;
+  
+  while [ `curl -s -o /dev/null -w "%{http_code}" http://localhost:9090/scorpio/v1/info/` -eq 500 ]; do sleep 10; done;
+  cd testsuite;
+  cd NGSI-LD_TestSuite-master;
+  node accumulator/accumulator.js &;
 
+  export EXCLUDED_TESTS="001|003|126|129|";
+  export TEST_ENDPOINT="http://localhost:9090";
+  export ACC_ENDPOINT="http://localhost:4444";
+  export NOTIFY_ENDPOINT="http://localhost:4444/acc";
+  export WEB_APP_PORT=4444;
 
+  npm test;
+  curl http://localhost:9090/scorpio/v1/info/
 
-    export EXCLUDED_TESTS="001|003|126|129|";
-    export TEST_ENDPOINT="http://localhost:9090";
-    export ACC_ENDPOINT="http://localhost:4444";
-    export NOTIFY_ENDPOINT="http://localhost:4444/acc";
-    export WEB_APP_PORT=4444;
-
-    npm test;
-    curl http://localhost:9090/scorpio/v1/info/
- 
 after_script: >
   cd kafka
   kafka_2.12-2.2.0/bin/zookeeper-server-stop.sh
@@ -74,11 +77,8 @@ after_script: >
 # see https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure
 sudo: true
 
-
-
 # cache the build tool's caches
 cache:
   npm: true
   directories:
     - $HOME/.m2
-  

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,12 @@ before_script:
 script:
   - cd testsuite
   - cd NGSI-LD_TestSuite-master
-  - node accumulator/accumulator.js &;
-  - export EXCLUDED_TESTS="001|003|126|129|"
+  - export EXCLUDED_TESTS="001|002|003|004|014|022|145|147|149|151|155|156|157|158|159|161|162"
   - export TEST_ENDPOINT="http://localhost:9090"
   - export ACC_ENDPOINT="http://localhost:4444"
   - export NOTIFY_ENDPOINT="http://localhost:4444/acc"
   - export WEB_APP_PORT=4444
+  - node accumulator/accumulator.js &;
   - npm test
   - curl http://localhost:9090/scorpio/v1/info/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,65 +7,69 @@ jdk:
 services:
   - postgresql
 
-env:
-  - TEST_ENDPOINT=http://localhost:9090 ACC_ENDPOINT=http://localhost:4444 NOTIFY_ENDPOINT=http://localhost:4444/acc WEB_APP_PORT=4444
-
-
 addons:
   postgresql: 9.6
   apt:
     packages:
     - postgresql-9.6-postgis-2.3
     - npm
-before_script:
-  - psql -U postgres -c "create extension postgis;"
-  - psql -U postgres -c "create database ngb;"
-  - psql -U postgres -c "create user ngb with password 'ngb';"
-  - psql -U postgres -c "alter database ngb owner to ngb;"  
-  - psql -U postgres -c "grant all privileges on database ngb to ngb;"
-  - psql -U postgres -c "alter role ngb superuser;"
-  - cd
-  - mkdir kafka
-  - cd kafka
-  - wget http://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz
-  - tar -xzf kafka_2.12-2.2.0.tgz
-  - kafka_2.12-2.2.0/bin/zookeeper-server-start.sh kafka_2.12-2.2.0/config/zookeeper.properties > /dev/null 2>&1 &
-  - sleep 12
-  - kafka_2.12-2.2.0/bin/kafka-server-start.sh kafka_2.12-2.2.0/config/server.properties > /dev/null 2>&1 &
-  - sleep 2
-  - cd ..
-  - mkdir testsuit
-  - cd testsuit
-  - git clone https://github.com/ScorpioBroker/NGSI-LD_TestSuite.git
-  - cd NGSI-LD_TestSuite
-  - npm install
-  - cd ..
-  - cd ..
+before_script: >
+    psql -U postgres -c "create extension postgis;";
+    psql -U postgres -c "create database ngb;";
+    psql -U postgres -c "create user ngb with password 'ngb';";
+    psql -U postgres -c "alter database ngb owner to ngb;"  ;
+    psql -U postgres -c "grant all privileges on database ngb to ngb;";
+    psql -U postgres -c "alter role ngb superuser;";
+    mkdir kafka;
+    cd kafka;
+    wget http://ftp-stud.hs-esslingen.de/pub/Mirrors/ftp.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz;
+    tar -xzf kafka_2.12-2.2.0.tgz;
+    kafka_2.12-2.2.0/bin/zookeeper-server-start.sh kafka_2.12-2.2.0/config/zookeeper.properties > /dev/null 2>&1 &;
+    sleep 12;
+    kafka_2.12-2.2.0/bin/kafka-server-start.sh kafka_2.12-2.2.0/config/server.properties > /dev/null 2>&1 &;
+    sleep 2;
+    cd ..;
+    mkdir testsuite;
+    cd testsuite;
+    curl -LO https://github.com/FIWARE/NGSI-LD_TestSuite/archive/master.zip;
+    shasum -a 256 master.zip;
+    unzip -q master.zip;
+    rm master.zip;
+    cd NGSI-LD_TestSuite-master;
+    npm install;
+    cd ../..
   
   
-script:
- - cd $TRAVIS_BUILD_DIR
- - mvn clean package -DskipDefault -PbuildForTest -B
- - java -jar ./SpringCloudModules/eureka/target/eureka-server.jar > /dev/null 2>&1 &
- #- java -jar ./SpringCloudModules/config-server/target/config-server.jar &
- - sleep 10
- - java -Dspring.profiles.active=aio -jar ./SpringCloudModules/gateway/target/gateway.jar > /dev/null 2>&1 &
- - sleep 10
- - java -Dspring.profiles.active=dev -jar ./AllInOneRunner/target/AllInOneRunner.jar > /dev/null 2>&1 &
- - sleep 100
- - while [ `curl -s -o /dev/null -w "%{http_code}" http://localhost:9090/scorpio/v1/info/` -eq 500 ]; do sleep 10; done
- - cd
- - cd testsuit 
- - cd NGSI-LD_TestSuite
- - node accumulator/accumulator.js &
- - npm test
- - curl http://localhost:9090/scorpio/v1/info/
+script: >
+    cd $TRAVIS_BUILD_DIR;
+    mvn clean package -DskipDefault -PbuildForTest -B;
+    java -jar ./SpringCloudModules/eureka/target/eureka-server.jar > /dev/null 2>&1 &
+ #- java -jar ./SpringCloudModules/config-server/target/config-server.jar &;
+    sleep 10;
+    java -Dspring.profiles.active=aio -jar ./SpringCloudModules/gateway/target/gateway.jar > /dev/null 2>&1 &;
+    sleep 10;
+    java -Dspring.profiles.active=dev -jar ./AllInOneRunner/target/AllInOneRunner.jar > /dev/null 2>&1 &;
+    sleep 100;
+    while [ `curl -s -o /dev/null -w "%{http_code}" http://localhost:9090/scorpio/v1/info/` -eq 500 ]; do sleep 10; done;
+    cd testsuite;
+    cd NGSI-LD_TestSuite-master;
+    node accumulator/accumulator.js &;
+
+
+
+    export EXCLUDED_TESTS="001|003|126|129|";
+    export TEST_ENDPOINT="http://localhost:9090";
+    export ACC_ENDPOINT="http://localhost:4444";
+    export NOTIFY_ENDPOINT="http://localhost:4444/acc";
+    export WEB_APP_PORT=4444;
+
+    npm test;
+    curl http://localhost:9090/scorpio/v1/info/
  
-after_script:
- - cd
- - cd kafka
- - kafka_2.12-2.2.0/bin/zookeeper-server-stop.sh
- - kafka_2.12-2.2.0/bin/kafka-server-stop.sh
+after_script: >
+  cd kafka
+  kafka_2.12-2.2.0/bin/zookeeper-server-stop.sh
+  kafka_2.12-2.2.0/bin/kafka-server-stop.sh
 
 # see https://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure
 sudo: true


### PR DESCRIPTION
@ScorpioBroker 

This PR tidies up the `.travis.yml` and alters the build to download and use the common NGSI-LD test suite 

The  NGSI-LD test suite has been amended to accept for multiple styles of `@context` whilst maintaining the same entities for all brokers.

All failing test have been  excluded using the following list:

```
EXCLUDED_TESTS="001|002|003|004|014|022|145|147|149|151|155|156|157|158|159|160|161|162"
```

Applying this change will allow the build to succeed, so thereafter you can use the test suite to stop regression. 
Obviously as more tests are created, then other inconsistencies may be found. Since **exactly** the same test suite is used on [Orion-LD](https://github.com/FIWARE/context.Orion-LD) this will help to maintain consistency.

Note that the results I am getting  [on travis](https://github.com/jason-fox/ScorpioBroker/tree/feature/common-test-suite) match the failures I get when running locally, so using this list we  more easily discuss if the remaining failures are real  issues in the broker, lack of clarity in the specification or faults within the tests themselves 