### PR TITLE
offline support via internal webserver issue #51

### DIFF
--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/constants/AppConstants.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/constants/AppConstants.java
@@ -31,6 +31,7 @@ public class AppConstants {
 	
 	
 	public final static byte[] NULL_BYTES = "null".getBytes();
+	public static final String CORE_CONTEXT_URL_SUFFIX = "ngsi-ld-core-context";
 
 
 }

--- a/Core/AtContextServer/src/main/java/eu/neclab/ngsildbroker/atcontextserver/controller/AtContextServerController.java
+++ b/Core/AtContextServer/src/main/java/eu/neclab/ngsildbroker/atcontextserver/controller/AtContextServerController.java
@@ -2,6 +2,8 @@ package eu.neclab.ngsildbroker.atcontextserver.controller;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.google.common.io.Files;
 
+import eu.neclab.ngsildbroker.commons.constants.AppConstants;
 import eu.neclab.ngsildbroker.commons.ldcontext.AtContext;
 import eu.neclab.ngsildbroker.commons.serialization.DataSerializer;
 
@@ -59,7 +62,7 @@ public class AtContextServerController {
 	public ResponseEntity<Object> getContextForEntity(HttpServletRequest request,
 			@PathVariable("contextId") String contextId) {
 		logger.trace("getAtContext() for " + contextId);
-		if(contextId.equals("ngsi-ld-core-context")) {
+		if(contextId.equals(AppConstants.CORE_CONTEXT_URL_SUFFIX)) {
 			return ResponseEntity.accepted().contentType(MediaType.APPLICATION_JSON).body(coreContext);
 		}
 		List<Object> contextes = atContext.getContextes(contextId);
@@ -72,7 +75,14 @@ public class AtContextServerController {
 
 	@GetMapping(name="atcontextget")
 	public ResponseEntity<Object> getAllContextes() {
-		return ResponseEntity.accepted().body(atContext.getAllContextes().toString());
+		StringBuilder body = new StringBuilder("{\n");
+		//Manuallly done because gson shows the actual byte values and not a string
+		Map<String, byte[]> contextMapping = atContext.getAllContextes();
+		for(Entry<String, byte[]> contextEntry: contextMapping.entrySet()) {
+			body.append("    \"" + contextEntry.getKey() + "\": \"" + new String(contextEntry.getValue()) + "\",\n");
+		}
+		body.append("}");
+		return ResponseEntity.accepted().contentType(MediaType.APPLICATION_JSON).body(body.toString());
 	}
 
 }


### PR DESCRIPTION
Addressing issue #51 providing a stored version of the core context via the internal at context server.
ld context resolver will fall back to the internal version if the external one fails to connect. People who know they are running offline can provide the internal url 
(e.g. http://localhost:9090/ngsi-ld/contextes/ngsi-ld-core-context/)
to the config param context.coreurl directly.
  