### PR TITLE
Historycontroller

### DIFF
--- a/History/HistoryManager/src/main/java/eu/neclab/ngsildbroker/historymanager/controller/HistoryController.java
+++ b/History/HistoryManager/src/main/java/eu/neclab/ngsildbroker/historymanager/controller/HistoryController.java
@@ -37,7 +37,7 @@ import eu.neclab.ngsildbroker.historymanager.service.HistoryService;
 import eu.neclab.ngsildbroker.historymanager.utils.Validator;
 
 @RestController
-@RequestMapping("/ngsi-ld/v1/temporal")
+@RequestMapping("/ngsi-ld/v1/temporal/entities")
 public class HistoryController {
 
 	private final static Logger logger = LoggerFactory.getLogger(HistoryController.class);
@@ -62,7 +62,7 @@ public class HistoryController {
 		this.httpUtils = HttpUtils.getInstance(contextResolver);
 	}
 
-	@PostMapping("/entities")
+	@PostMapping
 	public ResponseEntity<byte[]> createTemporalEntity(HttpServletRequest request,
 			@RequestBody(required = false) String payload) {
 		try {
@@ -84,7 +84,7 @@ public class HistoryController {
 		}
 	}
 
-	@GetMapping("/entities")
+	@GetMapping
 	public ResponseEntity<byte[]> retrieveTemporalEntity(HttpServletRequest request) {
 		String params = request.getQueryString();
 		try {
@@ -115,7 +115,7 @@ public class HistoryController {
 		}
 	}
 
-	@GetMapping("/entities/{entityId}")
+	@GetMapping("/{entityId}")
 	public ResponseEntity<byte[]> retrieveTemporalEntityById(HttpServletRequest request,
 			@PathVariable("entityId") String entityId) {
 		String params = request.getQueryString();
@@ -140,7 +140,7 @@ public class HistoryController {
 		}
 	}
 
-	@DeleteMapping("/entities/{entityId}")
+	@DeleteMapping("/{entityId}")
 	public ResponseEntity<byte[]> deleteTemporalEntityById(HttpServletRequest request,
 			@PathVariable("entityId") String entityId) {
 		try {
@@ -160,7 +160,7 @@ public class HistoryController {
 		}
 	}
 
-	@PostMapping("/entities/{entityId}/attrs")
+	@PostMapping("/{entityId}/attrs")
 	public ResponseEntity<byte[]> addAttrib2TemopralEntity(HttpServletRequest request,
 			@PathVariable("entityId") String entityId, @RequestBody(required = false) String payload) {
 		try {
@@ -181,7 +181,7 @@ public class HistoryController {
 		}
 	}
 
-	@DeleteMapping("/entities/{entityId}/attrs/{attrId}")
+	@DeleteMapping("/{entityId}/attrs/{attrId}")
 	public ResponseEntity<byte[]> deleteAttrib2TemporalEntity(HttpServletRequest request,
 			@PathVariable("entityId") String entityId, @PathVariable("attrId") String attrId) {
 		try {
@@ -201,7 +201,7 @@ public class HistoryController {
 		}
 	}
 
-	@PatchMapping("/entities/{entityId}/attrs/{attrId}/{instanceId}")
+	@PatchMapping("/{entityId}/attrs/{attrId}/{instanceId}")
 	public ResponseEntity<byte[]> modifyAttribInstanceTemporalEntity(HttpServletRequest request,
 			@PathVariable("entityId") String entityId, @PathVariable("attrId") String attrId,
 			@PathVariable("instanceId") String instanceId, @RequestBody(required = false) String payload) {
@@ -227,7 +227,7 @@ public class HistoryController {
 		}
 	}
 
-	@DeleteMapping("/entities/{entityId}/attrs/{attrId}/{instanceId}")
+	@DeleteMapping("/{entityId}/attrs/{attrId}/{instanceId}")
 	public ResponseEntity<byte[]> deleteAtrribInstanceTemporalEntity(HttpServletRequest request,
 			@PathVariable("entityId") String entityId, @PathVariable("attrId") String attrId,
 			@PathVariable("instanceId") String instanceId) {

--- a/SpringCloudModules/gateway/src/main/resources/application-aaio.yml
+++ b/SpringCloudModules/gateway/src/main/resources/application-aaio.yml
@@ -79,7 +79,7 @@ zuul:
       stripPrefix: false
     history-manager:
       sensitiveHeaders:
-      path: /ngsi-ld/v1/temporal/**
+      path: /ngsi-ld/v1/temporal/entities/**
       serviceId: aio-runner
       stripPrefix: false
     atcontext-server:

--- a/SpringCloudModules/gateway/src/main/resources/application-aio.yml
+++ b/SpringCloudModules/gateway/src/main/resources/application-aio.yml
@@ -80,7 +80,7 @@ zuul:
       stripPrefix: false
     history-manager:
       sensitiveHeaders:
-      path: /ngsi-ld/v1/temporal/**
+      path: /ngsi-ld/v1/temporal/entities/**
       serviceId: aio-runner
       stripPrefix: false
     atcontext-server:

--- a/SpringCloudModules/gateway/src/main/resources/application.yml
+++ b/SpringCloudModules/gateway/src/main/resources/application.yml
@@ -98,7 +98,7 @@ zuul:
       stripPrefix: false
     history-manager:
       sensitiveHeaders:
-      path: /ngsi-ld/v1/temporal/**
+      path: /ngsi-ld/v1/temporal/entities/**
       serviceId: HISTORY-MANAGER
       stripPrefix: false
     atcontext-server:


### PR DESCRIPTION
Minor change to the history controller and the gateway mappings to match the querymanagers mappings so that the base get and post annotations can be empty. This solves the whole trailing / situation.

