### PR TITLE
#554 fix. Users need to use double quotes (") around URLs or links in…

### DIFF
--- a/QueryManager/src/main/java/eu/neclab/ngsildbroker/queryhandler/controller/QueryController.java
+++ b/QueryManager/src/main/java/eu/neclab/ngsildbroker/queryhandler/controller/QueryController.java
@@ -193,7 +193,8 @@ public class QueryController {
             if (index != -1) {
                 uri = uri.substring(0, index);
             }
-            q = uri.replaceAll("\"","");
+			q=uri;
+//            q = uri.replaceAll("\"","");
         } else {
 			q = null;
 		}


### PR DESCRIPTION
… the q query.

Dot is reserved for sub-attributes in the q query.  So, if user is having dots in the attribute name then he must provide this in the double quotes.

like this : &q="http://www.industry-fusion.org/schema%23product_name"=="MasterCut%20Compact" 