### PR TITLE
fixing getType SQL query adding as in queryDAO

### DIFF
--- a/QueryManager/src/main/java/eu/neclab/ngsildbroker/queryhandler/repository/QueryDAO.java
+++ b/QueryManager/src/main/java/eu/neclab/ngsildbroker/queryhandler/repository/QueryDAO.java
@@ -220,7 +220,7 @@ public class QueryDAO {
 	public Uni<Map<String, Object>> getTypes(String tenantId) {
 		return clientManager.getClient(tenantId, false).onItem().transformToUni(client -> {
 			return client
-					.preparedQuery("SELECT DISTINCT myTypes from (SELECT to_jsonb(unnest(e_types)) as myTypes from entity UNION ALL SELECT to_jsonb(e_type) as myTypes from csourceinformation);")
+					.preparedQuery("SELECT DISTINCT myTypes from (SELECT to_jsonb(unnest(e_types)) as myTypes from entity UNION ALL SELECT to_jsonb(e_type) as myTypes from csourceinformation) as NA;")
 					.execute().onItem().transform(rows -> {
 						Map<String, Object> result = Maps.newHashMap();
 						result.put(NGSIConstants.JSON_LD_TYPE, Lists.newArrayList(NGSIConstants.NGSI_LD_ENTITY_LIST));


### PR DESCRIPTION
Fixing the error `ERROR: subquery in FROM must have an alias` when querying `ngsi-ld/v1/types`. 


![image (5)](https://github.com/ScorpioBroker/ScorpioBroker/assets/10358848/c523f827-fc4e-404e-b14b-dd00706a36fd)


The fix is to give the subquery in the FROM clause an alias (i.e. a name), so that it can be uniquely identified in the query, even if the alias is not used. 
https://pganalyze.com/docs/log-insights/app-errors/U115