### PR TITLE
Fix error on valid `Via` headers.

### DIFF
--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/ViaHeaders.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/ViaHeaders.java
@@ -22,7 +22,7 @@ public class ViaHeaders {
 					String protocolPart = parts[0];
 					int versionSplitPos = protocolPart.indexOf('/');
 					String protocol;
-					if (versionSplitPos != -1) {
+					if (versionSplitPos == -1) {
 						protocol = "http";
 					} else {
 						protocol = protocolPart.substring(0, versionSplitPos).toLowerCase();


### PR DESCRIPTION
A header like `Via: 1.1 localhost`, which is valid, throws an error due to a small mistake in the logic, which is fixed by this PR.

Fixes #628