### PR TITLE
Fix inline linked entity retrieval

### DIFF
--- a/Commons/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/Commons/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -1027,7 +1027,7 @@ public class JsonLdApi {
 					result.add(compact(activeCtx, expandedName, attribInstance, true, -1, options, langQuery));
 					continue;
 				}
-				Map<String, Object> attribMap = (Map<String, Object>) attribInstance;
+				Map<String, Object> attribMap = new LinkedHashMap<>((Map<String, Object>) attribInstance);
 				Map<String, Object> resultMap = new LinkedHashMap<>(attribMap.size());
 				Object typeObj = attribMap.remove(NGSIConstants.JSON_LD_TYPE);
 				if (typeObj == null) {


### PR DESCRIPTION
Hello, after updating to V6.0.0, we've been unable to request linked entities with inline join. The following error occurs:

```
2025-10-07 09:04:51,460 ERROR [eu.nec.ngs.com.too.HttpUtils] (vert.x-eventloop-thread-16) Exception :: : java.lang.UnsupportedOperationException
    at java.base/java.util.ImmutableCollections.uoe(Unknown Source)
    at java.base/java.util.ImmutableCollections$AbstractImmutableMap.remove(Unknown Source)
    at com.github.jsonldjava.core.JsonLdApi.compactAttribute(JsonLdApi.java:1032)
    at com.github.jsonldjava.core.JsonLdApi.commonSubAttribsCompaction(JsonLdApi.java:1207)
    at com.github.jsonldjava.core.JsonLdApi.compactAttribute(JsonLdApi.java:1120)
    at com.github.jsonldjava.core.JsonLdApi.compactEntity(JsonLdApi.java:831)
    at com.github.jsonldjava.core.JsonLdApi.compact(JsonLdApi.java:218)
    at com.github.jsonldjava.core.JsonLdApi.compact(JsonLdApi.java:178)
    at com.github.jsonldjava.core.JsonLdProcessor.lambda$compact$0(JsonLdProcessor.java:153)
    at io.smallrye.context.impl.wrappers.SlowContextualFunction.apply(SlowContextualFunction.java:21)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.performInnerSubscription(UniOnItemTransformToUni.java:68)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.onItem(UniOnItemTransformToUni.java:57)
    at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownItem$KnownItemSubscription.forward(UniCreateFromKnownItem.java:38)
    at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownItem.subscribe(UniCreateFromKnownItem.java:23)
    at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni.subscribe(UniOnItemTransformToUni.java:25)
    at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni.subscribe(UniOnItemTransformToUni.java:25)
    at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransform.subscribe(UniOnItemTransform.java:22)
    at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransform.subscribe(UniOnItemTransform.java:22)
    at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
    at io.smallrye.mutiny.operators.uni.UniOnItemOrFailureFlatMap$UniOnItemOrFailureFlatMapProcessor.performInnerSubscription(UniOnItemOrFailureFlatMap.java:99)
    at io.smallrye.mutiny.operators.uni.UniOnItemOrFailureFlatMap$UniOnItemOrFailureFlatMapProcessor.onItem(UniOnItemOrFailureFlatMap.java:54)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.onItem(UniOnItemTransformToUni.java:60)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransform$UniOnItemTransformProcessor.onItem(UniOnItemTransform.java:43)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.onItem(UniOnItemTransformToUni.java:60)
    at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownItem$KnownItemSubscription.forward(UniCreateFromKnownItem.java:38)
    at io.smallrye.mutiny.operators.uni.builders.UniCreateFromKnownItem.subscribe(UniCreateFromKnownItem.java:23)
    at io.smallrye.mutiny.operators.AbstractUni.subscribe(AbstractUni.java:35)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.performInnerSubscription(UniOnItemTransformToUni.java:81)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransformToUni$UniOnItemTransformToUniProcessor.onItem(UniOnItemTransformToUni.java:57)
    at io.smallrye.mutiny.operators.uni.UniOperatorProcessor.onItem(UniOperatorProcessor.java:47)
    at io.smallrye.mutiny.operators.uni.UniOnItemTransform$UniOnItemTransformProcessor.onItem(UniOnItemTransform.java:43)
    at io.smallrye.mutiny.vertx.AsyncResultUni.lambda$subscribe$1(AsyncResultUni.java:35)
    at io.smallrye.mutiny.vertx.DelegatingHandler.handle(DelegatingHandler.java:25)
    at io.vertx.core.impl.future.FutureImpl$4.onSuccess(FutureImpl.java:176)
    at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
    at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259)
    at io.vertx.sqlclient.impl.QueryResultBuilder.tryComplete(QueryResultBuilder.java:88)
    at io.vertx.sqlclient.impl.QueryResultBuilder.tryComplete(QueryResultBuilder.java:32)
    at io.vertx.core.Promise.complete(Promise.java:66)
    at io.vertx.core.Promise.handle(Promise.java:51)
    at io.vertx.core.Promise.handle(Promise.java:29)
    at io.vertx.core.impl.future.FutureImpl$4.onSuccess(FutureImpl.java:176)
    at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
    at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:259)
    at io.vertx.core.impl.future.Composition$1.onSuccess(Composition.java:62)
    at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
    at io.vertx.core.impl.future.Transformation$1.onSuccess(Transformation.java:61)
    at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:66)
    at io.vertx.core.impl.future.SucceededFuture.addListener(SucceededFuture.java:88)
    at io.vertx.core.impl.future.Transformation.onSuccess(Transformation.java:42)
    at io.vertx.core.impl.future.FutureBase.lambda$emitSuccess$0(FutureBase.java:60)
    at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
    at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:405)
    at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:998)
    at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
    at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
    at java.base/java.lang.Thread.run(Unknown Source)
```

We've traced it to an attempt to remove a property from an inmutable map (https://github.com/dmunozv04/ScorpioBroker/blob/b48409a8154967abbbc65dcc865a6e65ae143d2f/Commons/src/main/java/com/github/jsonldjava/core/JsonLdApi.java#L1032). Preliminar testing seems to suggest that this simple fix solves the issue, at least on our environment. 

Please do let us know if you want to look further into this, and the possible performance regressions of having to copy a Map



This PR is created by @ficodes , who has signed the Entity CLA.