### PR TITLE
Fix startup failure when PostgreSQL username contains a dot (#666)

### DIFF
--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/storage/ConnectionManager.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/storage/ConnectionManager.java
@@ -85,9 +85,6 @@ public class ConnectionManager {
 	@ConfigProperty(name = "pool.initialSize")
 	int initialSize;
 
-	@ConfigProperty(name = "scorpio.postgres.username")
-	String dbUser;
-
 	@ConfigProperty(name = "scorpio.postgres.disablejit", defaultValue = "true")
 	boolean disableJIT;
 
@@ -96,9 +93,9 @@ public class ConnectionManager {
 	@PostConstruct
 	void setup() throws URISyntaxException {
 		if (disableJIT) {
-			executeQuery(null, "ALTER USER " + dbUser + " SET jit = off;", null, false).await().indefinitely();
+			executeQuery(null, "ALTER USER CURRENT_USER SET jit = off;", null, false).await().indefinitely();
 		} else {
-			executeQuery(null, "ALTER USER " + dbUser + " SET jit = on;", null, false).await().indefinitely();
+			executeQuery(null, "ALTER USER CURRENT_USER SET jit = on;", null, false).await().indefinitely();
 		}
 
 		URI uri = new URI(reactiveDefaultUrl);


### PR DESCRIPTION
Fixes #666.

`ConnectionManager.setup()` built the `ALTER USER` statement by concatenating the configured username, so a username containing a dot (e.g. `username.scorpio`) was parsed by PostgreSQL as a `schema.object` separator, causing `syntax error at or near .` at startup.

This switches to the `CURRENT_USER` keyword, which PostgreSQL resolves to the connected user — exactly the user we want to set `jit` on — and removes the now-unused `dbUser` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)