### PR TITLE
Validate entity/subscription IDs on creation (#661)

### DIFF
--- a/Commons/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
+++ b/Commons/src/main/java/com/github/jsonldjava/core/JsonLdApi.java
@@ -1541,8 +1541,11 @@ public class JsonLdApi {
 							// compacted version and should not be expanded
 							// expandedValue = activeCtx.expandIri((String) value, true, false, null, null);
 
-							if (!((String) value).contains(":") && !ngsiElement.isFromHasValue()) {
-								throw new ResponseException(ErrorType.BadRequestData, "IDs need to be URIs");
+							if (!ngsiElement.isFromHasValue()) {
+								// validate the id the same way GET/DELETE do on the path parameter so
+								// that ids with spaces or characters not permitted by RFC 3986 are
+								// rejected at creation time instead of becoming unmanageable resources
+								HttpUtils.validateUri((String) value);
 							}
 							expandedValue = activeCtx.expandIri((String) value, true, false, null, null);
 


### PR DESCRIPTION
Fixes #661.

## Problem

Scorpio accepted entity and subscription IDs containing spaces and characters not permitted by RFC 3986 (e.g. `urn:ngsi-ld:Test:has spaces`, `<>{}|\^`) on `POST`, but then rejected the same IDs on `GET`/`DELETE` with `"id is not a URI"`. The result was orphaned resources that appeared in list queries but could not be retrieved, updated, or deleted through the API — only via direct DB access.

## Root cause

`GET`/`DELETE` validate the path id with `HttpUtils.validateUri(...)`, which builds a `new URI(...)` and requires it to be absolute, rejecting spaces/illegal characters. On `POST`, the id flows through JSON-LD expansion in `JsonLdApi`, where the only check was that the `@id` contained a colon — far weaker than the path validation.

## Fix

Replace the weak "contains a colon" check in the expansion path with the same `HttpUtils.validateUri(...)` call used by `GET`/`DELETE`, keeping the existing `isFromHasValue()` guard so it only applies to real ids (entities, subscriptions, registrations, relationship objects) and not arbitrary `@id`s inside property values.

Invalid IDs are now rejected with `400 BadRequestData` at creation time, matching the issue's expected behavior. Valid URIs (including URNs like `urn:ngsi-ld:...`) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
