### PR TITLE
Implement CSF (Context Source Filter) handling end-to-end

### DIFF
--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/RegistrationEntry.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/RegistrationEntry.java
@@ -89,6 +89,7 @@ public class RegistrationEntry {
 	boolean retrieveEntityMap;
 	RemoteHost host;
 	Context context;
+	Map<String, Object> registration;
 
 	public RegistrationEntry(String cId, String eId, String eIdp, String type, String eProp, String eRel,
 			Shape location, String[] scopes, long expiresAt, int regMode, boolean createEntity, boolean updateEntity,
@@ -581,6 +582,12 @@ public class RegistrationEntry {
 				}
 			}
 
+			// keep a reference to the full expanded registration so a context source
+			// filter (csf) can be evaluated against the registration's descriptive
+			// properties in memory. all entries of one registration share the payload.
+			for (RegistrationEntry regEntry : result) {
+				regEntry.registration = payload;
+			}
 			return result;
 		});
 	}
@@ -1411,6 +1418,10 @@ public class RegistrationEntry {
 
 	public void setContext(Context context) {
 		this.context = context;
+	}
+
+	public Map<String, Object> registration() {
+		return registration;
 	}
 
 }

--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/Subscription.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/Subscription.java
@@ -27,6 +27,7 @@ import eu.neclab.ngsildbroker.commons.datatypes.terms.GeoQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.LanguageQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.OmitTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.PickTerm;
+import eu.neclab.ngsildbroker.commons.datatypes.terms.CSFQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.QQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.ScopeQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.TemporalQueryTerm;
@@ -78,7 +79,7 @@ public class Subscription implements Serializable {
 	@JsonIgnore
 	private QQueryTerm ldQuery;
 	@JsonIgnore
-	private QQueryTerm csfQuery;
+	private CSFQueryTerm csfQuery;
 	@JsonIgnore
 	private ScopeQueryTerm scopeQuery;
 	private DataSetIdTerm datasetIdTerm;
@@ -904,7 +905,7 @@ public class Subscription implements Serializable {
 		}
 		this.csfQueryString = csfQueryString;
 		if (csfQueryString != null) {
-			this.csfQuery = QueryParser.parseQuery(csfQueryString, ldContext);
+			this.csfQuery = QueryParser.parseCSFQuery(csfQueryString, ldContext);
 		} else {
 			this.csfQuery = null;
 		}
@@ -914,7 +915,7 @@ public class Subscription implements Serializable {
 		return isActive;
 	}
 
-	public QQueryTerm getCsfQuery() {
+	public CSFQueryTerm getCsfQuery() {
 		return csfQuery;
 	}
 

--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/terms/CSFQueryTerm.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/terms/CSFQueryTerm.java
@@ -1,11 +1,14 @@
 package eu.neclab.ngsildbroker.commons.datatypes.terms;
 
+import java.util.Map;
+import java.util.Set;
+
 import com.github.jsonldjava.core.Context;
 
 public class CSFQueryTerm extends QQueryTerm {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 707863320739851119L;
 
@@ -15,6 +18,50 @@ public class CSFQueryTerm extends QQueryTerm {
 
 	public CSFQueryTerm(Context context) {
 		super(context);
+	}
+
+	/**
+	 * Evaluates this context source filter against the expanded payload of a
+	 * registration, in memory.
+	 * <p>
+	 * Unlike a regular q query - which cannot be resolved up front because the
+	 * matching entities may be spread across several brokers - a CSF works on the
+	 * values a registration declares about itself. Those are fully known locally,
+	 * so the filter can be evaluated before any context source is contacted, which
+	 * is why the evaluation lives here on {@link CSFQueryTerm} rather than on
+	 * {@link QQueryTerm}.
+	 *
+	 * @param registration the expanded NGSI-LD CSourceRegistration payload
+	 * @return {@code true} if the registration satisfies the filter
+	 */
+	public boolean eval(Map<String, Object> registration) {
+		if (registration == null) {
+			return false;
+		}
+		return evalTree(this, registration);
+	}
+
+	/**
+	 * Walks the q tree (groups via firstChild, conjunction/disjunction via
+	 * next/nextAnd) the same way {@link QQueryTerm#calculate(java.util.List)} does
+	 * for entities, but evaluates each leaf against the registration map using the
+	 * existing {@link QQueryTerm#calculate(Map, Set)} comparator.
+	 */
+	private static boolean evalTree(QQueryTerm term, Map<String, Object> registration) {
+		boolean result;
+		if (term.getFirstChild() != null && !term.isLinkedQ()) {
+			result = evalTree(term.getFirstChild(), registration);
+		} else {
+			result = term.calculate(registration, (Set<String>) null);
+		}
+		if (term.hasNext()) {
+			if (term.isNextAnd()) {
+				result = result && evalTree(term.getNext(), registration);
+			} else {
+				result = result || evalTree(term.getNext(), registration);
+			}
+		}
+		return result;
 	}
 
 }

--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/tools/EntityTools.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/tools/EntityTools.java
@@ -48,6 +48,7 @@ import eu.neclab.ngsildbroker.commons.datatypes.terms.GeoQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.LanguageQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.OmitTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.PickTerm;
+import eu.neclab.ngsildbroker.commons.datatypes.terms.CSFQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.QQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.ScopeQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.TypeQueryTerm;
@@ -959,18 +960,18 @@ public final class EntityTools {
 
 	public static Collection<QueryRemoteHost> getRemoteQueries(String tenant,
 			List<Tuple3<String[], TypeQueryTerm, String>> idsAndTypeQueryAndIdPattern, AttrsQueryTerm attrsQuery,
-			QQueryTerm qQuery, GeoQueryTerm geoQuery, ScopeQueryTerm scopeQuery, LanguageQueryTerm langQuery,
-			Table<String, String, List<RegistrationEntry>> tenant2CId2RegEntries, Context context,
-			EntityCache fullEntityCache, boolean splitEntities, ViaHeaders viaHeaders) {
-		return getRemoteQueries(idsAndTypeQueryAndIdPattern, attrsQuery, qQuery, geoQuery, scopeQuery, langQuery,
+			QQueryTerm qQuery, CSFQueryTerm csf, GeoQueryTerm geoQuery, ScopeQueryTerm scopeQuery,
+			LanguageQueryTerm langQuery, Table<String, String, List<RegistrationEntry>> tenant2CId2RegEntries,
+			Context context, EntityCache fullEntityCache, boolean splitEntities, ViaHeaders viaHeaders) {
+		return getRemoteQueries(idsAndTypeQueryAndIdPattern, attrsQuery, qQuery, csf, geoQuery, scopeQuery, langQuery,
 				tenant2CId2RegEntries.row(tenant).values(), context, fullEntityCache, viaHeaders, splitEntities);
 	}
 
 	public static Collection<QueryRemoteHost> getRemoteQueries(
 			List<Tuple3<String[], TypeQueryTerm, String>> idsAndTypeQueryAndIdPattern, AttrsQueryTerm attrsQuery,
-			QQueryTerm qQuery, GeoQueryTerm geoQuery, ScopeQueryTerm scopeQuery, LanguageQueryTerm langQuery,
-			Collection<List<RegistrationEntry>> regEntries, Context context, EntityCache fullEntityCache,
-			ViaHeaders viaHeaders, boolean isDist) {
+			QQueryTerm qQuery, CSFQueryTerm csf, GeoQueryTerm geoQuery, ScopeQueryTerm scopeQuery,
+			LanguageQueryTerm langQuery, Collection<List<RegistrationEntry>> regEntries, Context context,
+			EntityCache fullEntityCache, ViaHeaders viaHeaders, boolean isDist) {
 
 		// ids, types, attrs, geo, scope
 		List<Map<QueryRemoteHost, QueryInfos>> remoteHost2QueryInfos = Lists.newArrayList();
@@ -1000,6 +1001,11 @@ public final class EntityTools {
 					QueryInfos ogQueryInfo = regEntry.matches(id, idPattern, typeQuery, attrsQuery, qQuery, geoQuery,
 							scopeQuery);
 					if (ogQueryInfo == null) {
+						continue;
+					}
+					// context source filter: skip registrations whose descriptive
+					// properties don't satisfy the csf
+					if (csf != null && !csf.eval(regEntry.registration())) {
 						continue;
 					}
 

--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/tools/QueryParser.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/tools/QueryParser.java
@@ -41,7 +41,12 @@ public class QueryParser {
 	}
 
 	public static CSFQueryTerm parseCSFQuery(String input, Context context) throws ResponseException {
-		return null;
+		if (input == null) {
+			return null;
+		}
+		CSFQueryTerm root = new CSFQueryTerm(context);
+		parseQueryIntoRoot(input, context, root);
+		return root;
 	}
 
 	public static QQueryTerm parseQuery(String input, Context context) throws ResponseException {
@@ -49,6 +54,12 @@ public class QueryParser {
 			return null;
 		}
 		QQueryTerm root = new QQueryTerm(context);
+		parseQueryIntoRoot(input, context, root);
+		return root;
+	}
+
+	private static QQueryTerm parseQueryIntoRoot(String input, Context context, QQueryTerm root)
+			throws ResponseException {
 		QQueryTerm current = root;
 		boolean readingAttrib = true;
 		boolean readingOperant = false;

--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/tools/SubscriptionTools.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/tools/SubscriptionTools.java
@@ -26,6 +26,7 @@ import eu.neclab.ngsildbroker.commons.datatypes.terms.AttrsQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.DataSetIdTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.GeoQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.LanguageQueryTerm;
+import eu.neclab.ngsildbroker.commons.datatypes.terms.CSFQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.QQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.ScopeQueryTerm;
 import eu.neclab.ngsildbroker.commons.datatypes.terms.TypeQueryTerm;
@@ -471,6 +472,7 @@ public class SubscriptionTools {
 			Collection<List<RegistrationEntry>> regEntries, Context context, ViaHeaders viaHeaders) {
 
 		// ids, types, attrs, geo, scope
+		CSFQueryTerm csf = sub.getCsfQuery();
 		List<Map<SubscriptionRemoteHost, QueryInfos>> remoteHost2QueryInfos = Lists.newArrayList();
 		if (idsAndTypeQueryAndIdPattern == null) {
 			idsAndTypeQueryAndIdPattern = Lists.newArrayList();
@@ -494,6 +496,11 @@ public class SubscriptionTools {
 					}
 
 					if (regEntry.matches(id, idPattern, typeQuery, attrsQuery, qQuery, geoQuery, scopeQuery) == null) {
+						continue;
+					}
+					// context source filter: skip registrations whose descriptive
+					// properties don't satisfy the subscription's csf
+					if (csf != null && !csf.eval(regEntry.registration())) {
 						continue;
 					}
 

--- a/HistoryQueryManager/src/main/java/eu/neclab/ngsildbroker/historyquerymanager/service/HistoryQueryService.java
+++ b/HistoryQueryManager/src/main/java/eu/neclab/ngsildbroker/historyquerymanager/service/HistoryQueryService.java
@@ -122,7 +122,7 @@ public class HistoryQueryService implements CSourceHandler {
 		if (localOnly) {
 			return local;
 		}
-		Map<RemoteHost, String> remoteHosts = getRemoteHostsForQuery(tenant, request.query(), context);
+		Map<RemoteHost, String> remoteHosts = getRemoteHostsForQuery(tenant, request.query(), context, csf);
 		if (remoteHosts.isEmpty()) {
 			return local;
 		}
@@ -417,7 +417,8 @@ public class HistoryQueryService implements CSourceHandler {
 		return result;
 	}
 
-	private Map<RemoteHost, String> getRemoteHostsForQuery(String tenant, String query, Context context) {
+	private Map<RemoteHost, String> getRemoteHostsForQuery(String tenant, String query, Context context,
+			CSFQueryTerm csf) {
 		Map<RemoteHost, String> result = new HashMap<>();
 		Map<String, String> queryMap = queryStrToMap(query);
 		Set<String> filteredIds = new HashSet<>();
@@ -427,6 +428,10 @@ public class HistoryQueryService implements CSourceHandler {
 		for (List<RegistrationEntry> regEntries : tenant2CId2RegEntries.row(tenant).values()) {
 			for (RegistrationEntry regEntry : regEntries) {
 				if (!regEntry.retrieveTemporal()) {
+					continue;
+				}
+				// context source filter: skip registrations the csf rejects
+				if (csf != null && !csf.eval(regEntry.registration())) {
 					continue;
 				}
 

--- a/QueryManager/src/main/java/eu/neclab/ngsildbroker/queryhandler/controller/QueryController.java
+++ b/QueryManager/src/main/java/eu/neclab/ngsildbroker/queryhandler/controller/QueryController.java
@@ -435,7 +435,8 @@ public class QueryController {
 				.transformToUni(params -> {
 					return queryService.getAndStoreEntityMap(tenant, params.getEntityMapToken(),
 							params.getIdsAndTypeAndIdPattern(), params.getAttrsQueryTerm(), params.getGeoQueryTerm(),
-							params.getqQueryTerm(), params.getScopeQueryTerm(), params.getLanguageQueryTerm(), 1, 0,
+							params.getqQueryTerm(), params.getCsfQueryTerm(), params.getScopeQueryTerm(),
+							params.getLanguageQueryTerm(), 1, 0,
 							params.getContext(), request.headers(), false, params.getDataSetIdTerm(), null, -1,
 							distEntities, params.getPickTerm(), params.getOmitTerm(), params.getCheckSum(),
 							params.getViaHeaders(), null, false, true, true, true, params.getOrderBy(),

--- a/QueryManager/src/main/java/eu/neclab/ngsildbroker/queryhandler/services/QueryService.java
+++ b/QueryManager/src/main/java/eu/neclab/ngsildbroker/queryhandler/services/QueryService.java
@@ -124,7 +124,7 @@ public class QueryService implements CSourceHandler {
 			DataSetIdTerm dataSetIdTerm, String join, int joinLevel, boolean entityDist, PickTerm pickTerm,
 			OmitTerm omitTerm, String checkSum, ViaHeaders viaHeaders, String typePattern,
 			boolean forceEntitymapCreation, OrderByTerm orderBy, boolean metadata) {
-		return getAndStoreEntityMap(tenant, qToken, idsAndTypeQueryAndIdPattern, attrsQuery, geoQuery, qQuery,
+		return getAndStoreEntityMap(tenant, qToken, idsAndTypeQueryAndIdPattern, attrsQuery, geoQuery, qQuery, csf,
 				scopeQuery, langQuery, limit, offSet, context, headersFromReq, doNotCompact, dataSetIdTerm, join,
 				joinLevel, entityDist, pickTerm, omitTerm, checkSum, viaHeaders, typePattern, localOnly,
 				forceEntitymapCreation || tokenProvided,
@@ -1819,7 +1819,8 @@ public class QueryService implements CSourceHandler {
 
 	public Uni<Tuple2<EntityCache, EntityMap>> getAndStoreEntityMap(String tenant, String qToken,
 			List<Tuple3<String[], TypeQueryTerm, String>> idsAndTypeQueryAndIdPattern, AttrsQueryTerm attrsQuery,
-			GeoQueryTerm geoQuery, QQueryTerm qQuery, ScopeQueryTerm scopeQuery, LanguageQueryTerm langQuery, int limit,
+			GeoQueryTerm geoQuery, QQueryTerm qQuery, CSFQueryTerm csf, ScopeQueryTerm scopeQuery,
+			LanguageQueryTerm langQuery, int limit,
 			int offset, Context context, io.vertx.core.MultiMap headersFromReq, boolean doNotCompact,
 			DataSetIdTerm dataSetIdTerm, String join, int joinLevel, boolean splitEntities, PickTerm pickTerm,
 			OmitTerm omitTerm, String queryCechksum, ViaHeaders viaHeaders, String typePattern, boolean localOnly,
@@ -1834,7 +1835,7 @@ public class QueryService implements CSourceHandler {
 		} else {
 			EntityCache fullEntityCache = new EntityCache();
 			Collection<QueryRemoteHost> remoteHost2Query = EntityTools.getRemoteQueries(tenant,
-					idsAndTypeQueryAndIdPattern, attrsQuery, qQuery, geoQuery, scopeQuery, langQuery,
+					idsAndTypeQueryAndIdPattern, attrsQuery, qQuery, csf, geoQuery, scopeQuery, langQuery,
 					tenant2CId2RegEntries, context, fullEntityCache, splitEntities, viaHeaders);
 			// remoteHost2Query.forEach(entry -> logger.debug(entry.toString()));
 			if (remoteHost2Query.isEmpty() || localOnly) {
@@ -2069,9 +2070,11 @@ public class QueryService implements CSourceHandler {
 			}
 			List<Tuple3<String[], TypeQueryTerm, String>> idsAndTypes = new ArrayList<>(1);
 			idsAndTypes.add(Tuple3.of(entityIds, typeQueryTerm, null));
+			// csf is null here: this is the linked-entity (join) traversal, not the
+			// primary source selection which already applied csf when building the map
 			Collection<QueryRemoteHost> remoteQueries = EntityTools.getRemoteQueries(idsAndTypes, null, linkedQ, null,
-					null, null, tenant2CId2RegEntries.row(tenant).values(), linkHeaders, fullEntityCache, viaHeaders,
-					splitEntities);
+					null, null, null, tenant2CId2RegEntries.row(tenant).values(), linkHeaders, fullEntityCache,
+					viaHeaders, splitEntities);
 			for (QueryRemoteHost remoteQuery : remoteQueries) {
 
 				unis.add(EntityTools.getRemoteEntities(remoteQuery, webClient, timeout, fedlimit, 0, ldService).onItem()

--- a/QueryManager/src/main/java/eu/neclab/ngsildbroker/queryhandler/services/QueryService.java
+++ b/QueryManager/src/main/java/eu/neclab/ngsildbroker/queryhandler/services/QueryService.java
@@ -131,7 +131,7 @@ public class QueryService implements CSourceHandler {
 				tokenProvided, count, orderBy, metadata)
 				.onItem().transformToUni(t -> {
 					return handleEntityMap(t.getItem2(), t.getItem1(), tenant, idsAndTypeQueryAndIdPattern,
-							attrsQuery, qQuery, geoQuery, scopeQuery, langQuery, limit, offSet, count,
+							attrsQuery, qQuery, csf, geoQuery, scopeQuery, langQuery, limit, offSet, count,
 							dataSetIdTerm, join, joinLevel, context, jsonKeys, headersFromReq, pickTerm, omitTerm,
 							viaHeaders, localOnly);
 
@@ -140,7 +140,8 @@ public class QueryService implements CSourceHandler {
 
 	private Uni<QueryResult> handleEntityMap(EntityMap entityMap, EntityCache entityCache, String tenant,
 			List<Tuple3<String[], TypeQueryTerm, String>> idsAndTypeQueryAndIdPattern, AttrsQueryTerm attrsQuery,
-			QQueryTerm qQuery, GeoQueryTerm geoQuery, ScopeQueryTerm scopeQuery, LanguageQueryTerm langQuery, int limit,
+			QQueryTerm qQuery, CSFQueryTerm csf, GeoQueryTerm geoQuery, ScopeQueryTerm scopeQuery,
+			LanguageQueryTerm langQuery, int limit,
 			int offSet, boolean count, DataSetIdTerm dataSetIdTerm, String join, int joinLevel, Context context,
 			Set<String> jsonKeys, io.vertx.core.MultiMap headersFromReq, PickTerm pickTerm, OmitTerm omitTerm,
 			ViaHeaders viaHeaders, boolean localOnly) {
@@ -214,7 +215,7 @@ public class QueryService implements CSourceHandler {
 				resultData.add(isolateForInlineJoin ? entityShellForJoin(cached) : cached);
 			});
 			if (qQuery != null && qQuery.hasLinkedQ()) {
-				return retrieveJoins(tenant, resultData, entityCache, context, qQuery, 0, -1, qQuery.getMaxJoinLevel(),
+				return retrieveJoins(tenant, resultData, entityCache, context, qQuery, csf, 0, -1, qQuery.getMaxJoinLevel(),
 						viaHeaders, entityMap.isDistEntities()).onItem().transformToUni(updatedEntityCache -> {
 							Map<String, Map<String, Object>> deleted = EntityTools.evaluateFilterQueries(result, qQuery,
 									null, null, attrsQuery, pickTerm, omitTerm, dataSetIdTerm, updatedEntityCache,
@@ -223,16 +224,16 @@ public class QueryService implements CSourceHandler {
 								if (entityMap.isChanged()) {
 									return queryDAO.storeEntityMap(tenant, entityMap.getId(), entityMap).onItem()
 											.transformToUni(v -> {
-												return doJoinIfNeeded(tenant, result, updatedEntityCache, context, join,
+												return doJoinIfNeeded(tenant, result, updatedEntityCache, context, csf, join,
 														joinLevel, viaHeaders, pickTerm, omitTerm,
 														entityMap.isDistEntities());
 											});
 								}
-								return doJoinIfNeeded(tenant, result, updatedEntityCache, context, join, joinLevel,
+								return doJoinIfNeeded(tenant, result, updatedEntityCache, context, csf, join, joinLevel,
 										viaHeaders, pickTerm, omitTerm, entityMap.isDistEntities());
 							} else {
 								return updateEntityMapAndRepull(deleted, entityMap, updatedEntityCache, tenant,
-										idsAndTypeQueryAndIdPattern, attrsQuery, qQuery, geoQuery, scopeQuery,
+										idsAndTypeQueryAndIdPattern, attrsQuery, qQuery, csf, geoQuery, scopeQuery,
 										langQuery, limit, offSet, count, dataSetIdTerm, join, joinLevel, context,
 										jsonKeys, headersFromReq, pickTerm, omitTerm, viaHeaders, localOnly);
 							}
@@ -241,7 +242,7 @@ public class QueryService implements CSourceHandler {
 				if (attrsQuery != null) {
 					attrsQuery.calculateQuery(resultData);
 				}
-				return doJoinIfNeeded(tenant, result, entityCache, context, join, joinLevel, viaHeaders, pickTerm,
+				return doJoinIfNeeded(tenant, result, entityCache, context, csf, join, joinLevel, viaHeaders, pickTerm,
 						omitTerm, entityMap.isDistEntities());
 			}
 		} else {
@@ -269,16 +270,16 @@ public class QueryService implements CSourceHandler {
 									if (entityMap.isChanged()) {
 										return queryDAO.storeEntityMap(tenant, entityMap.getId(), entityMap).onItem()
 												.transformToUni(v -> {
-													return doJoinIfNeeded(tenant, result, updatedEntityCache, context,
+													return doJoinIfNeeded(tenant, result, updatedEntityCache, context, csf,
 															join, joinLevel, viaHeaders, pickTerm, omitTerm,
 															entityMap.isDistEntities());
 												});
 									}
-									return doJoinIfNeeded(tenant, result, updatedEntityCache, context, join, joinLevel,
+									return doJoinIfNeeded(tenant, result, updatedEntityCache, context, csf, join, joinLevel,
 											viaHeaders, pickTerm, omitTerm, entityMap.isDistEntities());
 								} else {
 									return updateEntityMapAndRepull(deleted, entityMap, updatedEntityCache, tenant,
-											idsAndTypeQueryAndIdPattern, attrsQuery, qQuery, geoQuery, scopeQuery,
+											idsAndTypeQueryAndIdPattern, attrsQuery, qQuery, csf, geoQuery, scopeQuery,
 											langQuery, limit, offSet, count, dataSetIdTerm, join, joinLevel, context,
 											jsonKeys, headersFromReq, pickTerm, omitTerm, viaHeaders, localOnly);
 								}
@@ -294,7 +295,7 @@ public class QueryService implements CSourceHandler {
 							if (qMaxJoinLevel < joinLevel) {
 								qMaxJoinLevel = joinLevel;
 							}
-							return retrieveJoins(tenant, resultData, entityCache, context, qQuery, 0, joinLevel,
+							return retrieveJoins(tenant, resultData, entityCache, context, qQuery, csf, 0, joinLevel,
 									qMaxJoinLevel, viaHeaders, false).onItem().transformToUni(updatedEntityCache2 -> {
 										if (!entityMap.isDistEntities()) {
 											Map<String, Map<String, Object>> deleted = EntityTools
@@ -305,17 +306,17 @@ public class QueryService implements CSourceHandler {
 													return queryDAO.storeEntityMap(tenant, entityMap.getId(), entityMap)
 															.onItem().transformToUni(v -> {
 																return doJoinIfNeeded(tenant, result,
-																		updatedEntityCache, context, join, joinLevel,
+																		updatedEntityCache, context, csf, join, joinLevel,
 																		viaHeaders, pickTerm, omitTerm,
 																		entityMap.isDistEntities());
 															});
 												}
-												return doJoinIfNeeded(tenant, result, updatedEntityCache2, context,
+												return doJoinIfNeeded(tenant, result, updatedEntityCache2, context, csf,
 														join, joinLevel, viaHeaders, pickTerm, omitTerm,
 														entityMap.isDistEntities());
 											} else {
 												return updateEntityMapAndRepull(deleted, entityMap, updatedEntityCache2,
-														tenant, idsAndTypeQueryAndIdPattern, attrsQuery, qQuery,
+														tenant, idsAndTypeQueryAndIdPattern, attrsQuery, qQuery, csf,
 														geoQuery, scopeQuery, langQuery, limit, offSet, count,
 														dataSetIdTerm, join, joinLevel, context, jsonKeys,
 														headersFromReq, pickTerm, omitTerm, viaHeaders, localOnly);
@@ -330,17 +331,17 @@ public class QueryService implements CSourceHandler {
 													return queryDAO.storeEntityMap(tenant, entityMap.getId(), entityMap)
 															.onItem().transformToUni(v -> {
 																return doJoinIfNeeded(tenant, result,
-																		updatedEntityCache, context, join, joinLevel,
+																		updatedEntityCache, context, csf, join, joinLevel,
 																		viaHeaders, pickTerm, omitTerm,
 																		entityMap.isDistEntities());
 															});
 												}
-												return doJoinIfNeeded(tenant, result, updatedEntityCache, context, join,
+												return doJoinIfNeeded(tenant, result, updatedEntityCache, context, csf, join,
 														joinLevel, viaHeaders, pickTerm, omitTerm,
 														entityMap.isDistEntities());
 											} else {
 												return updateEntityMapAndRepull(deleted, entityMap, updatedEntityCache,
-														tenant, idsAndTypeQueryAndIdPattern, attrsQuery, qQuery,
+														tenant, idsAndTypeQueryAndIdPattern, attrsQuery, qQuery, csf,
 														geoQuery, scopeQuery, langQuery, limit, offSet, count,
 														dataSetIdTerm, join, joinLevel, context, jsonKeys,
 														headersFromReq, pickTerm, omitTerm, viaHeaders, localOnly);
@@ -503,10 +504,11 @@ public class QueryService implements CSourceHandler {
 	}
 
 	private Uni<QueryResult> doJoinIfNeeded(String tenant, QueryResult result, EntityCache entityCache, Context context,
-			String join, int joinLevel, ViaHeaders viaHeaders, PickTerm pick, OmitTerm omit, boolean splitEntities) {
+			CSFQueryTerm csf, String join, int joinLevel, ViaHeaders viaHeaders, PickTerm pick, OmitTerm omit,
+			boolean splitEntities) {
 		if (join != null && joinLevel > 0) {
 			List<Map<String, Object>> resultData = result.getData();
-			return retrieveJoins(tenant, resultData, entityCache, context, null, 0, joinLevel, joinLevel, viaHeaders,
+			return retrieveJoins(tenant, resultData, entityCache, context, null, csf, 0, joinLevel, joinLevel, viaHeaders,
 					splitEntities).onItem().transformToUni(updatedCache2 -> {
 						boolean doFlatJoin = NGSIConstants.FLAT.equals(join);
 						if (doFlatJoin) {
@@ -679,7 +681,8 @@ public class QueryService implements CSourceHandler {
 	private Uni<QueryResult> updateEntityMapAndRepull(Map<String, Map<String, Object>> deleted, EntityMap entityMap,
 			EntityCache entityCache, String tenant,
 			List<Tuple3<String[], TypeQueryTerm, String>> idsAndTypeQueryAndIdPattern, AttrsQueryTerm attrsQuery,
-			QQueryTerm qQuery, GeoQueryTerm geoQuery, ScopeQueryTerm scopeQuery, LanguageQueryTerm langQuery, int limit,
+			QQueryTerm qQuery, CSFQueryTerm csf, GeoQueryTerm geoQuery, ScopeQueryTerm scopeQuery,
+			LanguageQueryTerm langQuery, int limit,
 			int offSet, boolean count, DataSetIdTerm dataSetIdTerm, String join, int joinLevel, Context context,
 			Set<String> jsonKeys, io.vertx.core.MultiMap headersFromReq, PickTerm pickTerm, OmitTerm omitTerm,
 			ViaHeaders viaHeaders, boolean localOnly) {
@@ -706,7 +709,7 @@ public class QueryService implements CSourceHandler {
 		// resultData.add(entityCache.getAllIds2EntityAndHosts().get(id2Hosts.getKey()).getItem1());
 		// });
 		//
-		// return doJoinIfNeeded(tenant, result, entityCache, context, join, joinLevel,
+		// return doJoinIfNeeded(tenant, result, entityCache, context, csf, join, joinLevel,
 		// viaHeaders, pickTerm, omitTerm,
 		// entityMap.isDistEntities());
 		//
@@ -717,15 +720,15 @@ public class QueryService implements CSourceHandler {
 		return fillCacheFromEntityMap(entityMap, entityCache, context, headersFromReq, true, tenant, offSet,
 				limit + (deleted.size() * 3)).onItem().transformToUni(updatedCache -> {
 					return handleEntityMap(entityMap, entityCache, tenant, idsAndTypeQueryAndIdPattern, attrsQuery,
-							qQuery, geoQuery, scopeQuery, langQuery, limit, offSet, count, dataSetIdTerm, join,
+							qQuery, csf, geoQuery, scopeQuery, langQuery, limit, offSet, count, dataSetIdTerm, join,
 							joinLevel, context, jsonKeys, headersFromReq, pickTerm, omitTerm, viaHeaders, localOnly);
 				});
 
 	}
 
 	private Uni<EntityCache> retrieveJoins(String tenant, Collection<Map<String, Object>> currentLevel,
-			EntityCache entityCache, Context context, QQueryTerm qQuery, int currentJoinLevel, int joinLevel,
-			int maxJoinLevel, ViaHeaders viaHeaders, boolean splitEntities) {
+			EntityCache entityCache, Context context, QQueryTerm qQuery, CSFQueryTerm csf, int currentJoinLevel,
+			int joinLevel, int maxJoinLevel, ViaHeaders viaHeaders, boolean splitEntities) {
 		Map<Set<String>, Set<String>> types2EntityIds = null;
 		if (currentJoinLevel < joinLevel) {
 			types2EntityIds = getAllTypesAndIds(currentLevel);
@@ -739,11 +742,11 @@ public class QueryService implements CSourceHandler {
 		if (types2EntityIds == null || types2EntityIds.isEmpty()) {
 			return Uni.createFrom().item(entityCache);
 		}
-		return getEntitiesFromUncalledHosts(tenant, types2EntityIds, entityCache, context, qQuery, viaHeaders, context,
-				splitEntities).onItem().transformToUni(t -> {
+		return getEntitiesFromUncalledHosts(tenant, types2EntityIds, entityCache, context, qQuery, csf, viaHeaders,
+				context, splitEntities).onItem().transformToUni(t -> {
 					int nextLevel = currentJoinLevel + 1;
 					if (nextLevel < maxJoinLevel && !t.getItem2().isEmpty()) {
-						return retrieveJoins(tenant, t.getItem2(), entityCache, context, qQuery, nextLevel, joinLevel,
+						return retrieveJoins(tenant, t.getItem2(), entityCache, context, qQuery, csf, nextLevel, joinLevel,
 								maxJoinLevel, viaHeaders, splitEntities);
 					}
 					return Uni.createFrom().item(t.getItem1());
@@ -2021,7 +2024,7 @@ public class QueryService implements CSourceHandler {
 
 	public Uni<Tuple2<EntityCache, Collection<Map<String, Object>>>> getEntitiesFromUncalledHosts(String tenant,
 			Map<Set<String>, Set<String>> types2EntityIds, EntityCache fullEntityCache, Context linkHeaders,
-			QQueryTerm linkedQ, ViaHeaders viaHeaders, Context context, boolean splitEntities) {
+			QQueryTerm linkedQ, CSFQueryTerm csf, ViaHeaders viaHeaders, Context context, boolean splitEntities) {
 		TypeQueryTerm typeQueryTerm = new TypeQueryTerm(linkHeaders);
 		TypeQueryTerm currentTypeQuery = typeQueryTerm;
 		Map<Set<String>, Set<String>> types2EntityIdsForDB = Maps.newHashMap();
@@ -2070,9 +2073,8 @@ public class QueryService implements CSourceHandler {
 			}
 			List<Tuple3<String[], TypeQueryTerm, String>> idsAndTypes = new ArrayList<>(1);
 			idsAndTypes.add(Tuple3.of(entityIds, typeQueryTerm, null));
-			// csf is null here: this is the linked-entity (join) traversal, not the
-			// primary source selection which already applied csf when building the map
-			Collection<QueryRemoteHost> remoteQueries = EntityTools.getRemoteQueries(idsAndTypes, null, linkedQ, null,
+			// apply the same context source filter when fetching linked entities
+			Collection<QueryRemoteHost> remoteQueries = EntityTools.getRemoteQueries(idsAndTypes, null, linkedQ, csf,
 					null, null, null, tenant2CId2RegEntries.row(tenant).values(), linkHeaders, fullEntityCache,
 					viaHeaders, splitEntities);
 			for (QueryRemoteHost remoteQuery : remoteQueries) {

--- a/RegistryManager/src/main/java/eu/neclab/ngsildbroker/registryhandler/repository/CSourceDAO.java
+++ b/RegistryManager/src/main/java/eu/neclab/ngsildbroker/registryhandler/repository/CSourceDAO.java
@@ -195,6 +195,18 @@ public class CSourceDAO {
 			sql.append(tempSql.toString().toLowerCase().replace("entity", "csource.reg"));
 			sqlAdded = true;
 		}
+		if (csf != null) {
+			// context source filter: an NGSI-LD query over the registrations'
+			// descriptive properties, applied against the registration jsonb the same
+			// way as the q term above
+			if (sqlAdded) {
+				sql.append(" AND ");
+			}
+			StringBuilder tempSql = new StringBuilder();
+			dollar = csf.toSqlOld(tempSql, dollar, tuple, true, false);
+			sql.append(tempSql.toString().toLowerCase().replace("entity", "csource.reg"));
+			sqlAdded = true;
+		}
 		if (typeQuery != null) {
 			if (sqlAdded) {
 				sql.append(" and ");
@@ -262,12 +274,6 @@ public class CSourceDAO {
 		sql.append(" offset $");
 		sql.append(dollar++);
 		tuple.addInteger(offset);
-		if (csf != null) {
-			// if (sqlAdded) {
-			// sql += " and ";
-			// }
-			// dollar++;
-		}
 		// String sqlString = sql.toString();
 		// logger.debug("SQL: " + sqlString);
 		// logger.debug("Tuple: " + tuple.deepToString());


### PR DESCRIPTION
## Summary

Implements CSF (Context Source Filter) handling end-to-end. Previously `parseCSFQuery()` returned `null`, so the `csf` parameter was silently ignored everywhere.

A CSF is an NGSI-LD query (clause 4.9 grammar, same as `q`) that filters **Context Source Registrations** by the values of the properties that describe them. Unlike a `q` query — whose matching entities may be distributed across brokers and so can't be resolved up front — a CSF works on what a registration declares about itself, which is fully known locally and can therefore be evaluated before any source is contacted.

## What changed

**Parsing** (`QueryParser`)
- `parseCSFQuery()` now parses the filter by reusing `parseQuery()`'s exact logic via a shared private helper, rooted in a `CSFQueryTerm`. `parseQuery()` behaviour is unchanged.

**Registration listing** (`CSourceDAO`)
- `GET /csourceRegistrations?csf=...` now filters: the csf is applied against the registration jsonb (`csource.reg`) the same way the existing `q` term is.

**In-memory evaluation** (`CSFQueryTerm`, `RegistrationEntry`)
- `CSFQueryTerm.eval(Map)` walks the query tree (groups + and/or) and evaluates each leaf against a registration's expanded payload, reusing `QQueryTerm`'s existing leaf comparator. The evaluation lives on `CSFQueryTerm` (not `QQueryTerm`) by design — only a CSF can be resolved locally up front.
- `RegistrationEntry` keeps a reference to the full expanded registration payload so the filter has something to evaluate against.

**Distributed source selection** — csf now filters which context sources are consulted on:
- entity queries (`GET /entities`, `POST /entityOperations/query`) — via `EntityTools.getRemoteQueries`
- subscriptions — via `SubscriptionTools.getRemoteSubscriptions` (`Subscription.csfQuery` is now a `CSFQueryTerm`)
- temporal queries — via `HistoryQueryService.getRemoteHostsForQuery`
- linked-entity joins (linked `q` queries and the `join`/`joinLevel` param) — threaded through the `handleEntityMap` join cluster

## Notes / scope

- Temporal retrieve-by-id takes no csf (consistent with the non-temporal retrieve path) and is left untouched.
- No new comparison logic was added on the distributed paths — csf is routed to the single `CSFQueryTerm.eval()` / `getRemoteQueries` filter.
- Verified with a full multi-module `mvn compile` (BUILD SUCCESS). Functional behaviour should be confirmed against the FIWARE NGSI-LD test suite, which CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
