### PR TITLE
fix: TermEntry orderDirection field not being set due to missing `this`

### DIFF
--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/terms/OrderByTerm.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/terms/OrderByTerm.java
@@ -39,7 +39,7 @@ public class OrderByTerm {
 
             this.orderGeometry = orderGeometry;
             if (orderDirection != null) {
-                if (orderDirection.contains("asc")) {
+                if (orderDirection.toLowerCase().contains("asc")) {
                     this.orderDirection = "ASC";
                 } else {
                     this.orderDirection = "DESC";

--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/terms/OrderByTerm.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/datatypes/terms/OrderByTerm.java
@@ -40,9 +40,9 @@ public class OrderByTerm {
             this.orderGeometry = orderGeometry;
             if (orderDirection != null) {
                 if (orderDirection.contains("asc")) {
-                    orderDirection = "ASC";
+                    this.orderDirection = "ASC";
                 } else {
-                    orderDirection = "DESC";
+                    this.orderDirection = "DESC";
                 }
             } else {
                 this.orderDirection = null;

--- a/Commons/src/test/java/eu/neclab/ngsildbroker/commons/datatypes/terms/OrderByTermTest.java
+++ b/Commons/src/test/java/eu/neclab/ngsildbroker/commons/datatypes/terms/OrderByTermTest.java
@@ -1,0 +1,46 @@
+package eu.neclab.ngsildbroker.commons.datatypes.terms;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OrderByTermTest {
+
+    @Test
+    public void testTermEntryOrderDirectionAsc() {
+        OrderByTerm orderByTerm = new OrderByTerm();
+        orderByTerm.addTerm("temperature", null, null, "asc", null);
+
+        StringBuilder sql = new StringBuilder();
+        orderByTerm.toSqlOrder(sql);
+
+        assertTrue(sql.toString().contains("ASC"), "Expected ASC in SQL but got: " + sql);
+        assertFalse(sql.toString().contains("DESC"), "Expected no DESC in SQL but got: " + sql);
+    }
+
+    @Test
+    public void testTermEntryOrderDirectionDesc() {
+        OrderByTerm orderByTerm = new OrderByTerm();
+        orderByTerm.addTerm("temperature", null, null, "desc", null);
+
+        StringBuilder sql = new StringBuilder();
+        orderByTerm.toSqlOrder(sql);
+
+        assertTrue(sql.toString().contains("DESC"), "Expected DESC in SQL but got: " + sql);
+        assertFalse(sql.toString().contains("ASC"), "Expected no ASC in SQL but got: " + sql);
+    }
+
+    @Test
+    public void testTermEntryOrderDirectionNull() {
+        OrderByTerm orderByTerm = new OrderByTerm();
+        orderByTerm.addTerm("temperature", null, null, null, null);
+
+        StringBuilder sql = new StringBuilder();
+        orderByTerm.toSqlOrder(sql);
+
+        assertFalse(sql.toString().contains("ASC"), "Expected no ASC in SQL but got: " + sql);
+        assertFalse(sql.toString().contains("DESC"), "Expected no DESC in SQL but got: " + sql);
+    }
+
+}

--- a/Commons/src/test/java/eu/neclab/ngsildbroker/commons/datatypes/terms/OrderByTermTest.java
+++ b/Commons/src/test/java/eu/neclab/ngsildbroker/commons/datatypes/terms/OrderByTermTest.java
@@ -32,6 +32,18 @@ public class OrderByTermTest {
     }
 
     @Test
+    public void testTermEntryOrderDirectionAscUppercase() {
+        OrderByTerm orderByTerm = new OrderByTerm();
+        orderByTerm.addTerm("temperature", null, null, "ASC", null);
+
+        StringBuilder sql = new StringBuilder();
+        orderByTerm.toSqlOrder(sql);
+
+        assertTrue(sql.toString().contains("ASC"), "Expected ASC in SQL but got: " + sql);
+        assertFalse(sql.toString().contains("DESC"), "Expected no DESC in SQL but got: " + sql);
+    }
+
+    @Test
     public void testTermEntryOrderDirectionNull() {
         OrderByTerm orderByTerm = new OrderByTerm();
         orderByTerm.addTerm("temperature", null, null, null, null);


### PR DESCRIPTION
  ## Summary

  - `TermEntry` constructor was normalizing the `orderDirection` parameter
    (lowercase → `"ASC"`/`"DESC"`) but assigning the result back to the local
    parameter instead of `this.orderDirection`, leaving the field always `null`
  - Additionally, the `contains("asc")` check was case-sensitive, so `"ASC"`
    (already uppercase) would fall through to `"DESC"`
  - Both bugs together meant `ORDER BY` queries never respected the requested
    sort direction

  ## Changes

  - `OrderByTerm.java`: use `this.orderDirection` in the assignment, and
    change `contains("asc")` to `equalsIgnoreCase("asc")` for robustness
  - `OrderByTermTest.java`: added unit tests covering ASC, DESC, lowercase,
    uppercase, and null direction

  Closes #672