### PR TITLE
Grouped attribute-existence q queries cause an internal error

### DIFF
--- a/Commons/src/main/java/eu/neclab/ngsildbroker/commons/tools/QueryParser.java
+++ b/Commons/src/main/java/eu/neclab/ngsildbroker/commons/tools/QueryParser.java
@@ -114,6 +114,11 @@ public class QueryParser {
 
 			} else if (b == ')') {
 				current.setOperant(operant);
+				if (!attribName.isEmpty()) {
+					current.setAttribute(attribName);
+					root.addAttrib(attribName);
+					attribName = "";
+				}
 
 				current = current.getParent();
 				readingAttrib = true;


### PR DESCRIPTION
## Summary
Fixes grouped `q` queries whose final term is a bare attribute-existence check.
When parsing a closing parenthesis, `QueryParser` saved the operand but not a pending attribute name. As a result, a query such as: `(test)` could produce an empty attribute node and fail during SQL generation with:
`Index 0 out of bounds for length 0`
The parser now persists the pending attribute before returning to the parent query term.
Related issue
Fixes #678
## Testing
Run the reproduction and confirm that the error is no longer present
```shell
curl -G 'http://localhost:9090/ngsi-ld/v1/entities' \
  --data-urlencode 'q=(Test1)' \
  -H 'Accept: application/ld+json'
```
## CLA
This PR is created by @Ficodes , who has signed the Entity CLA.
## AI notice
An AI agent (codex) was used to assist searching for the bug after experiencing it on a development environment. It has then been verified by a human (me) before opening this issue/PR